### PR TITLE
Send a message to Console when it attempts to execute a command

### DIFF
--- a/src/main/java/me/kevinnovak/treasurehunt/LanguageManager.java
+++ b/src/main/java/me/kevinnovak/treasurehunt/LanguageManager.java
@@ -19,7 +19,7 @@ public class LanguageManager {
     public String chestListHeader, chestListChestLine, chestListMorePages, chestListNoChests, chestListFooter;
     public String topHuntersHeader, topHuntersHunterLine, topHuntersMorePages, topHuntersNoHunters, topHuntersFooter;
     public String day, days, hour, hours, minute, minutes, second, seconds;
-    public String consoleChestSpawned, consoleChestSpawnFailed, consoleAnnounceTime, consoleChestDespawned, consoleChestFound;
+    public String consoleChestSpawned, consoleChestSpawnFailed, consoleAnnounceTime, consoleChestDespawned, consoleChestFound, consoleCommandNotAllowed;
 
     public LanguageManager(TreasureHunt plugin) {
         this.plugin = plugin;
@@ -92,5 +92,6 @@ public class LanguageManager {
         this.consoleAnnounceTime = colorConv.convert(languageData.getString("console.announceTime"));
         this.consoleChestDespawned = colorConv.convert(languageData.getString("console.chestDespawned"));
         this.consoleChestFound = colorConv.convert(languageData.getString("console.chestFound"));
+        this.consoleCommandNotAllowed = colorConv.convert(languageData.getString("console.commandNotAllowed"));
     }
 }

--- a/src/main/java/me/kevinnovak/treasurehunt/TreasureHunt.java
+++ b/src/main/java/me/kevinnovak/treasurehunt/TreasureHunt.java
@@ -735,7 +735,7 @@ public final class TreasureHunt extends JavaPlugin implements Listener {
         // ======================
         // if command sender is the console, let them know, cancel command
         if (!(sender instanceof Player)) {
-            // TO-DO: send message to console
+            sender.sendMessage(langMan.consolePrefix + langMan.consoleCommandNotAllowed);
             return true;
         }
         Player player = (Player) sender;

--- a/src/main/java/me/kevinnovak/treasurehunt/TreasureHunt.java
+++ b/src/main/java/me/kevinnovak/treasurehunt/TreasureHunt.java
@@ -46,6 +46,7 @@ public final class TreasureHunt extends JavaPlugin implements Listener {
     private List<Material> spawnUnder = new ArrayList<Material>();
     private List<Material> dontSpawnOn = new ArrayList<Material>();
     private boolean protectAgainstBreak, protectAgainstBurn, protectAgainstExplode;
+    private boolean notifyAdminsOnChestSpawnFail;
 
     // Plugin
     private List<TreasureChest> chests = new ArrayList<TreasureChest>();
@@ -173,6 +174,8 @@ public final class TreasureHunt extends JavaPlugin implements Listener {
         this.protectAgainstBreak = getConfig().getBoolean("protectAgainst.break");
         this.protectAgainstBurn = getConfig().getBoolean("protectAgainst.burn");
         this.protectAgainstExplode = getConfig().getBoolean("protectAgainst.explode");
+
+        this.notifyAdminsOnChestSpawnFail = getConfig().getBoolean("notifyAdminsOnChestSpawnFail");
 
         return true;
     }
@@ -312,11 +315,14 @@ public final class TreasureHunt extends JavaPlugin implements Listener {
         if (this.getAvailableChests().size() < maxChests) {
             Location treasureLocation = getTreasureLocation();
             if (treasureLocation.getBlockX() == -1 && treasureLocation.getBlockY() == -1 && treasureLocation.getBlockZ() == -1) {
-                // TO-DO: Annouce to only admins
-                if (sender != null) {
+                if (this.notifyAdminsOnChestSpawnFail)  // Notify all admins
+                    Bukkit.getOnlinePlayers().stream()
+                            .filter(p -> p.hasPermission(perm.start))
+                            .forEach(p -> p.sendMessage(langMan.chestSpawnFailed));
+                else  // Notify only the sender
                     sender.sendMessage(langMan.chestSpawnFailed);
-                }
-                this.log(langMan.consoleChestSpawnFailed);
+
+                this.log(langMan.consoleChestSpawnFailed);  // Log the failure regardless
             } else {
                 UUID id = UUID.randomUUID();
 

--- a/src/main/java/me/kevinnovak/treasurehunt/TreasureHunt.java
+++ b/src/main/java/me/kevinnovak/treasurehunt/TreasureHunt.java
@@ -319,8 +319,9 @@ public final class TreasureHunt extends JavaPlugin implements Listener {
                     Bukkit.getOnlinePlayers().stream()
                             .filter(p -> p.hasPermission(perm.start))
                             .forEach(p -> p.sendMessage(langMan.chestSpawnFailed));
-                else  // Notify only the sender
-                    sender.sendMessage(langMan.chestSpawnFailed);
+                else
+                    if (sender != null)  // Notify only the sender
+                            sender.sendMessage(langMan.chestSpawnFailed);
 
                 this.log(langMan.consoleChestSpawnFailed);  // Log the failure regardless
             } else {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -106,3 +106,5 @@ protectAgainst:
   break: true
   burn: true
   explode: true
+
+notifyAdminsOnChestSpawnFail: true

--- a/src/main/resources/language.yml
+++ b/src/main/resources/language.yml
@@ -72,3 +72,4 @@ console:
   announceTime: 'The {RARITY} chest at {LOCATION} will disappear in {TIME}.'
   chestDespawned: 'The {RARITY} chest at {LOCATION} disappeared without being found.'
   chestFound: '{PLAYER} found a {RARITY} treasure at {LOCATION}.'
+  commandNotAllowed: 'An in-game player must use this command.'


### PR DESCRIPTION
Currently, when a command is sent via the console, the onCommand method in TreasureHunt.java does nothing, instead stopping the execution of the command without providing the CommandSender any additional information.

Changes:
- language.yml:
    - Add console.commandNotAllowed message
- LanguageManager.java:
    - Add new public String (consoleCommandNotAllowed)
- TreasureHunt.java:
    - Send langMan.consoleCommandNotAllowed to CommandSender when it is not a Player